### PR TITLE
Quality percentage from packet numbers

### DIFF
--- a/connmon.sh
+++ b/connmon.sh
@@ -1033,7 +1033,10 @@ Run_PingTest(){
 	if [ "$PINGCOUNT" -gt 1 ]; then
 		ping="$(tail -n 1 "$pingfile"  | cut -f4 -d"/")"
 		jitter="$(echo "$TOTALDIFF" "$DIFFCOUNT" | awk '{printf "%4.3f\n",$1/$2}')"
-		linequal="$(echo 100 "$(tail -n 2 "$pingfile" | head -n 1 | cut -f3 -d"," | awk '{$1=$1};1' | cut -f1 -d"%")" | awk '{printf "%4.3f\n",$1-$2}')"
+#		linequal="$(echo 100 "$(tail -n 2 "$pingfile" | head -n 1 | cut -f3 -d"," | awk '{$1=$1};1' | cut -f1 -d"%")" | awk '{printf "%4.3f\n",$1-$2}')"
+		pkt_trans="$(tail -n 2 "$pingfile" | head -n 1 | cut -f1 -d"," | cut -f1 -d" ")"
+		pkt_rec="$(tail -n 2 "$pingfile" | head -n 1 | cut -f2 -d"," | cut -f2 -d" ")"
+       		linequal="$(echo "$pkt_rec" "$pkt_trans" | awk '{printf "%4.2f\n",100*$1/$2}')"   
 	fi
 	
 	Process_Upgrade


### PR DESCRIPTION
Dear Jack Yaz,

I acted on my suggestion in snbforums. I have no hands-on experience with all this. But it's exciting trying and sharing... Your most welcome to reject this. It's probably not up to your quality/testing standards.

Instead of reading the percentage from ping output (without decimal), this takes the packet numbers from ping output, and computes the percentage.
Can be partly tested with the following bit of code, based on an example of ping output from Merlin dash.
It seems to work end-to-end but I could not assess the impact for the database or the webUI. And I had no drop at the moment, so just 100,0%.
And I also have no shell experience...

test () {
        text="300 packets transmitted, 299 packets received, 1% packet loss"
        echo $text
        pkt_trans="$(echo "$text" | cut -f1 -d"," | cut -f1 -d" ")"
          pkt_rec="$(echo "$text" | cut -f2 -d"," | cut -f2 -d" ")"
        echo $pkt_trans
        echo $pkt_rec
        qual="$(echo "$pkt_rec" "$pkt_trans" | awk '{printf "%4.2f\n",100*$1/$2}')"
        echo $qual
}
test


It will return:
300 packets transmitted, 299 packets received, 1% packet loss
300
299
99.67