### PR TITLE
Fix token auth and hardcode org=influxdata request parameter

### DIFF
--- a/connmon.sh
+++ b/connmon.sh
@@ -330,7 +330,7 @@ Conf_FromSettings(){
 			sed -i "s/connmon_//g;s/ /=/g" "$TMPFILE"
 			while IFS='' read -r line || [ -n "$line" ]; do
 				SETTINGNAME="$(echo "$line" | cut -f1 -d'=' | awk '{print toupper($1)}')"
-				SETTINGVALUE="$(echo "$line" | cut -f2 -d'=')"
+				SETTINGVALUE="$(echo "$line" | cut -f2- -d'=')"
 				if [ "$SETTINGNAME" = "NOTIFICATIONS_PUSHOVER_LIST" ] || [ "$SETTINGNAME" = "NOTIFICATIONS_WEBHOOK_LIST" ] || [ "$SETTINGNAME" = "NOTIFICATIONS_EMAIL_LIST" ]; then
 					SETTINGVALUE="$(echo "$SETTINGVALUE" | sed 's~||||~,~g')"
 				fi
@@ -2116,7 +2116,7 @@ Conf_Parameters(){
 			esac
 		;;
 		check)
-			NOTIFICATION_SETTING="$(grep "$2=" "$SCRIPT_CONF" | cut -f2 -d"=")"
+			NOTIFICATION_SETTING="$(grep "$2=" "$SCRIPT_CONF" | cut -f2- -d"=")"
 			echo "$NOTIFICATION_SETTING"
 		;;
 	esac

--- a/connmon.sh
+++ b/connmon.sh
@@ -2018,7 +2018,7 @@ SendToInfluxDB(){
 		INFLUX_AUTHHEADER="$(Conf_Parameters check NOTIFICATIONS_INFLUXDB_APITOKEN)"
 	fi
 
-	/usr/sbin/curl -fsL --retry 3 --connect-timeout 15 --output /dev/null -XPOST "$NOTIFICATIONS_INFLUXDB_PROTO://$NOTIFICATIONS_INFLUXDB_HOST:$NOTIFICATIONS_INFLUXDB_PORT/api/v2/write?bucket=$NOTIFICATIONS_INFLUXDB_DB&precision=s" \
+	/usr/sbin/curl -fsL --retry 3 --connect-timeout 15 --output /dev/null -XPOST "$NOTIFICATIONS_INFLUXDB_PROTO://$NOTIFICATIONS_INFLUXDB_HOST:$NOTIFICATIONS_INFLUXDB_PORT/api/v2/write?bucket=$NOTIFICATIONS_INFLUXDB_DB&org=influxdata&precision=s" \
 --header "Authorization: Token $INFLUX_AUTHHEADER" --header "Accept-Encoding: gzip" \
 --data-raw "ping value=$PING $TIMESTAMP
 jitter value=$JITTER $TIMESTAMP


### PR DESCRIPTION
I've encountered two issues when running the script form the dev branch.

1. Influxdb now requires the org name to part of the HTTP GET parameters. Could this be added as an additional field to the UI?
2. The Conf_FromSettings function seems to strip off equal signs from the strings passed as values. Breaking my Auth Token that end with a double equal sign. https://github.com/jackyaz/connmon/blob/7c7e37d8b32b71d0d0af715d6aeb6343f5efece7/connmon.sh#L333C13-L333C13